### PR TITLE
🐛 FIX: proxy functionality breaking cors settings

### DIFF
--- a/lib/api_proxy_middleware.js
+++ b/lib/api_proxy_middleware.js
@@ -21,7 +21,7 @@ function cookieToHeaderDecorator(proxy_request_options, source_request) {
 }
 
 function removeServiceCorsHeadersDecorator(headers) {
-	if (headers['access-control-allow-origin']) delete headers['access-control-allow-origin']
+	headers['access-control-allow-origin'] = process.env.CORS_ORIGINS
 
 	return headers
 }


### PR DESCRIPTION
The response from the proxy is the proxied service's cors settings. I thought it would be enough just to delete the header, but turns out that means '*' which prevents sending credentials. This should sort it out