### PR TITLE
👌 Improve development experience by omitting ssl certs

### DIFF
--- a/lib/__tests__/cookies.spec.js
+++ b/lib/__tests__/cookies.spec.js
@@ -6,7 +6,7 @@ describe('cookies', () => {
 		beforeEach(() => {
 			jest.resetModules()
 
-			process.env = { ...OLD_ENV, BASE_URL: 'http://mock.no' }
+			process.env = { ...OLD_ENV, BASE_URL: 'http://mock.no', NODE_ENV: 'production' }
 			this.cookies = require('../cookies') // must be imported after mocking the env vars
 
 			delete process.env.NODE_ENV

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -6,7 +6,7 @@ const COOKIE_OPTIONS = Object.freeze({
 	domain: BASE_URL.hostname,
 	httpOnly: true,
 	sameSite: 'strict',
-	secure: true,
+	secure: process.env.NODE_ENV === 'production',
 	path: '/'
 })
 


### PR DESCRIPTION
Spent an unreasonable time trying to figure out a way to enable ssl when developing to not have to put logic solely for the development environment in production code, but gave up. If anyone have any ideas, I'll glady listen to them