### PR TITLE
👌 Improve acquisition of version in pipeline workflow

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -46,7 +46,7 @@ jobs:
           node-version: '12.x'
       - run: npm ci
 
-      - run: echo "::set-env name=RELEASE_VERSION::$(npm view gatekeeper version)"
+      - run: echo "::set-env name=RELEASE_VERSION::$(cat package.json | jq -r .version)"
 
       - name: Publish Docker image
         uses: elgohr/Publish-Docker-Github-Action@2.12


### PR DESCRIPTION
Found a cleaner way to acquire the package version

EDIT: This is actually a bug fix. Seems like nothing has been built since version 0.0.4 due to the way it gathers version information