### PR TITLE
👌 Improve helm charts to handle multiple environments

### DIFF
--- a/helm-charts/gatekeeper/Chart.yaml
+++ b/helm-charts/gatekeeper/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: An OAuth2 OIDC handler for SPA's and static frontends
 name: gatekeeper
-version: 0.1.0
+version: 0.1.1

--- a/helm-charts/gatekeeper/templates/deployment.yaml
+++ b/helm-charts/gatekeeper/templates/deployment.yaml
@@ -35,18 +35,6 @@ spec:
               containerPort: {{ .Values.service.internalPort }}
               protocol: TCP
           env:
-            - name: BASE_URL
-              value: https://gatekeeper.k8s{{ template "with-environment" . }}.oslo.kommune.no
-            - name: CORS_ORIGINS
-              value: https://apis.k8s{{ template "with-environment" . }}.oslo.kommune.no
-            - name: DISCOVERY_URL
-              value: https://login{{ template "with-environment" . }}.oslo.kommune.no/auth/realms/api-catalog/.well-known/openid-configuration
-            - name: SUCCESSFUL_LOGIN_ORIGIN
-              value: https://apis.k8s{{ template "with-environment" . }}.oslo.kommune.no
-            - name: UPSTREAMS
-              value: api-catalog=https://api-catalog.k8s{{ template "with-environment" . }}.oslo.kommune.no;data=https://api.data-dev.oslo.systems;teams=https://devportal-teams.k8s{{ template "with-environment" . }}.oslo.kommune.no
-            - name: ERROR_URL
-              value: https://apis.k8s{{ template "with-environment" . }}.oslo.kommune.no/error
           {{- with .Values.app.env }}
             {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/helm-charts/gatekeeper/templates/ingress.yaml
+++ b/helm-charts/gatekeeper/templates/ingress.yaml
@@ -23,17 +23,22 @@ metadata:
     {{- end }}
   {{- end }}
 spec:
-    {{- if and .Values.ingress.tls (eq .Values.ingress.tls true) }}
+  {{- if and .Values.ingress.tls (eq .Values.ingress.tls true) }}
   tls:
     - hosts:
-        - {{ .Values.ingress.host.subdomain }}.k8s{{ template "with-environment" . }}.oslo.kommune.no
+        {{- range .Values.ingress.hosts }}
+        - {{ . | quote }}
+          {{- end }}
+  {{- end }}
   rules:
-    - host: {{ .Values.ingress.host.subdomain }}.k8s{{ template "with-environment" . }}.oslo.kommune.no
+    {{- $externalPort := .Values.service.externalPort }}
+    {{- range .Values.ingress.hosts }}
+    - host: {{ . | quote }}
       http:
         paths:
           - path: /
             backend:
               serviceName: {{ $fullName }}
-              servicePort: {{ .Values.service.externalPort }}
-    {{- end}}
-{{- end}}
+              servicePort: {{ $externalPort }}
+    {{- end }}
+  {{- end }}

--- a/helm-charts/gatekeeper/values-test.yaml
+++ b/helm-charts/gatekeeper/values-test.yaml
@@ -1,0 +1,43 @@
+# Default values for dev-starter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+nameOverride: ""
+fullnameOverride: ""
+environment: test
+
+imagePullSecret: githubpackages
+
+app:
+  image:
+    repository: docker.pkg.github.com/oslokommune/gatekeeper/gatekeeper
+    tag: latest
+  volumeMounts: []
+    #- name: tmp
+    #  mountPath: /app/tmp
+  env:
+    - name: CLIENT_ID
+      value: gatekeeper
+    - name: CLIENT_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: gatekeeper-client-secret
+          key: password.txt
+    - name: BASE_URL
+      value: https://gatekeeper.k8s-test.oslo.kommune.no
+    - name: CORS_ORIGINS
+      value: https://apis.k8s-test.oslo.kommune.no;http://localhost:3333
+    - name: DISCOVERY_URL
+      value: https://login-test.oslo.kommune.no/auth/realms/api-catalog/.well-known/openid-configuration
+    - name: SUCCESSFUL_LOGIN_ORIGIN
+      value: https://apis.k8s-test.oslo.kommune.no;
+    - name: UPSTREAMS
+      value: api-catalog=https://api-catalog.k8s-test.oslo.kommune.no;data=https://api.data-dev.oslo.systems;teams=https://devportal-teams.k8s-test.oslo.kommune.no
+    - name: ERROR_URL
+      value: https://apis.k8s-test.oslo.kommune.no/error
+    - name: REDIS_URI
+      value: redis://dp-redis:6379
+  hosts:
+    - gatekeeper.api-test.oslo.kommune.no
+    - gatekeeper.k8s-test.oslo.kommune.no

--- a/helm-charts/gatekeeper/values.yaml
+++ b/helm-charts/gatekeeper/values.yaml
@@ -19,6 +19,7 @@ imagePullSecret: githubpackages
 app:
   image:
     repository: docker.pkg.github.com/oslokommune/gatekeeper/gatekeeper
+    tag: latest
     pullPolicy: Always
   resources:
     limits:
@@ -50,6 +51,18 @@ app:
         secretKeyRef:
           name: gatekeeper-client-secret
           key: password.txt
+    - name: BASE_URL
+      value: https://gatekeeper.k8s.oslo.kommune.no
+    - name: CORS_ORIGINS
+      value: https://apis.k8s.oslo.kommune.no
+    - name: DISCOVERY_URL
+      value: https://login.oslo.kommune.no/auth/realms/api-catalog/.well-known/openid-configuration
+    - name: SUCCESSFUL_LOGIN_ORIGIN
+      value: https://apis.k8s.oslo.kommune.no
+    - name: UPSTREAMS
+      value: api-catalog=https://api-catalog.k8s.oslo.kommune.no;data=https://api.data-dev.oslo.systems;teams=https://devportal-teams.k8s.oslo.kommune.no
+    - name: ERROR_URL
+      value: https://apis.k8s.oslo.kommune.no/error
     - name: REDIS_URI
       value: redis://dp-redis:6379
 

--- a/makefile
+++ b/makefile
@@ -19,11 +19,15 @@ push-image:
 release: build push-image
 	@echo "🚀 Release successfully built. We are ready to deploy"
 
-deploy:
+deploy-test:
 	helm --tiller-namespace=developerportal-test --namespace=developerportal-test upgrade \
-		--set environment=test \
 		--set app.image.tag=${VERSION} \
+		--values helm-charts/gatekeeper/values-test.yaml \
 		--install ${NAME} helm-charts/gatekeeper
+deploy-production:
+	helm --tiller-namespace=developerportal --namespace=developerportal upgrade \
+		--set app.image.tag=${VERSION} \
+
 
 run: ## Run the Gatekeeper locally
 	npx nodemon server.js


### PR DESCRIPTION
values.yaml is now production values and values-test.yaml is test values. I don't think the {{ with-environment }} helper is the right way to go. One should be able to deploy it anywhere just by changing the values. Especially now that we might be moving our stack(s) to AWS

When at some point I'm deploying the Gatekeeper to a private cluster, I'll generalize even more and add an values-production.yaml