### PR TITLE
✅ Add MIT licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Oslo Kommune
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "gatekeeper",
   "version": "1.0.10",
   "description": "handles auth",
+  "license": "MIT",
   "main": "server.js",
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
Consider this an application for open sourcing the Gatekeeper.

### Why open source the Gatekeeper
* I believe it has value for more people than just Oslo kommune. It drastically simplifies (im my opinion) the whole experience of authentication when dealing with an SPA. 
* If more people would start using it, I believe it would have a benefit for us from a security perspective due to a wider set of reviewers. 
* I personally want to see more of the public using Oslo Kommune's and Origo's "products". I think it could help our cause, improve our perceived and our actual value. 
* As from my understanding, we want to be a symbol of how to do things. Sharing is how we want to do things. 

### Why the MIT license
It's the most permissive license as far as I know. I see no point in restricting anything related to the Gatekeeper. It's built ontop of the shoulders of lots of other MIT licensed software, and should hope to contribute back. 

### Costs / complications due to open sourcing the Gatekeeper
* If no one else starts using it, it will act as a blue print for our security related internals. I plan on mitigating this by writing an article describing the Gatekeeper in hopes of attracting some attention. We could consider timeboxing the "open source"-ness. I'm curious if there is an established strategy for open sourcing projects?
* If the Gatekeeper sees a lot of activity, there might be costs related to managing the project. I feel theres no point in mitigating this at such an early stage
 