### PR TITLE
Improve logging experience

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -27,27 +27,26 @@ const requestLogMiddleware = expressWinston.logger({
 	headerBlacklist: ['cookie', 'authorization']
 })
 
-const LogStatementType = Object.freeze({
+const MetricType = Object.freeze({
 	SUCCESSFUL_LOGIN: 'successful_login',
 	isLegalType(type) {
 		return Object.keys(this).some(key => this[key] === type)
 	}
 })
-class LogStatement {
-	constructor(type, value) {
-		if (!LogStatementType.isLegalType(type)) throw new Error('Invalid log statement type')
 
-		this.type = type
-		if (value) this.value = value
-	}
-	publish() {
-		log.info('LogStatement', { ...this })
-	}
+function logMetric(type, value) {
+	if (!MetricType.isLegalType(type)) throw new Error('Invalid log metric type')
+
+	const meta = { type }
+
+	if (value) meta.value = value
+
+	log.info('metric', meta)
 }
 
 module.exports = {
 	log,
+	logMetric,
+	MetricType,
 	requestLogMiddleware,
-	LogStatementType,
-	LogStatement
 }

--- a/lib/oauth/auth_code_flow/callback_handler.js
+++ b/lib/oauth/auth_code_flow/callback_handler.js
@@ -3,7 +3,7 @@ const queryString = require('query-string')
 
 const cookies = require('../../cookies')
 const { generateErrorRedirect, asyncErrorMiddleware } = require('../../error')
-const { LogStatement, LogStatementType } = require('../../logging')
+const { logMetric, MetricType } = require('../../logging')
 const { StateVerificationError, deleteState, verifyState } = require('../../state')
 const storage = require('../../storage')
 const { ValidationError, verifyLegalNanoid, verifyLegalCode } = require('../../validators')
@@ -70,7 +70,7 @@ function setupCodeExchangeHandler(token_endpoint, redirect_uri) {
 		await storage.deleteRedirect(state_id)
 
 		res.redirect(redirect)
-		new LogStatement(LogStatementType.SUCCESSFUL_LOGIN).publish()
+		logMetric(MetricType.SUCCESSFUL_LOGIN)
 	}
 }
 


### PR DESCRIPTION
- [x] Set default log level to info
- [x] Add class for delivering structured log info for aggregation in Kibana

Can be tested by making a logtest.js file in project directory with the following contents:
```
const { logMetric, MetricType } = require('./lib/logging')

logMetric(MetricType.SUCCESSFUL_LOGIN)
```