### PR TITLE
🐛 Fix dockerfile including potential secrets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,6 @@
-node_modules/
-sslcerts/
-helm-charts/
-.idea/
-.github/
+*
 
-makefile
-README.md
-.env
-.env.*
-.gitignore
+!./lib
+!./package-lock.json
+!./package.json
+!./server.js


### PR DESCRIPTION
I noticed docker containers were containing secrets. To mitigate this, we set the .dockerignore to ignore everything by default and whitelist what we want to include

To test: 
1. echo "super secret token" > token.txt
2. make release
3. make run-in-docker
4. docker exec -it gatekeeper ls -la 

Verify that there is no token.txt file there