### PR TITLE
🐛 Fix elastic merging log objects due to lack of uniqueness

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -37,7 +37,7 @@ const MetricType = Object.freeze({
 function logMetric(type, value) {
 	if (!MetricType.isLegalType(type)) throw new Error('Invalid log metric type')
 
-	const meta = { type }
+	const meta = { '@timestamp': new Date().toISOString(), type }
 
 	if (value) meta.value = value
 


### PR DESCRIPTION
To fix identical objects, we introduce a timestamp to make them unique. Elasticsearch can be picky about the timestamp format. .toISOString() has been tested to verify it being parsed correctly