### PR TITLE
🐛 Fix exception when not supplying an upstream

### DIFF
--- a/lib/api_proxy_middleware.js
+++ b/lib/api_proxy_middleware.js
@@ -3,7 +3,7 @@ const proxy = require('express-http-proxy')
 const cookies = require('./cookies')
 const { log } = require('./logging')
 
-function createRouteToUpstreamMap(raw_string) {
+function createRouteToUpstreamMap(raw_string = '') {
 	const stripped = raw_string
 		.replace(/\s/g, '')
 		.replace(/"/g, '')


### PR DESCRIPTION
The Gatekeeper used to crash when not supplying an upstream. Since we're bragging about the proxy functionality being optional, it would be nice if it would actually work. This extremely large patch fixes that

To test:
1. Start the gatekeeper without supplying an UPSTREAMS variable
2. Ensure there is no warnings / errors