### PR TITLE
🐛 Fix 413 entity too large bug

### DIFF
--- a/lib/api_proxy_middleware.js
+++ b/lib/api_proxy_middleware.js
@@ -52,7 +52,8 @@ function removeServiceCorsHeadersDecorator(headers, userReq) {
 function generateProxy(upstream_url) {
 	return proxy(upstream_url, {
 		proxyReqOptDecorator: cookieToHeaderDecorator,
-		userResHeaderDecorator: removeServiceCorsHeadersDecorator
+		userResHeaderDecorator: removeServiceCorsHeadersDecorator,
+		limit: '20mb'
 	})
 }
 


### PR DESCRIPTION
The express http proxy library introduces a limit on request bodies for some reason. I'm increasing it as a temp fix. Creating an issue to discuss how to resolve it permanently