### PR TITLE
🐛 Fix hard coded token cookie keys

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -36,6 +36,8 @@ function clear(res, key, options = {}) {
 }
 
 module.exports = {
+	COOKIE_ACCESS_TOKEN,
+	COOKIE_REFRESH_TOKEN,
 	setStateId: (res, id) =>
 		set(res, COOKIE_STATE_ID, id, { path: '/callback', sameSite: 'lax' }),
 	getStateId: (req) => get(req, COOKIE_STATE_ID),

--- a/lib/oauth/token_refresh_middleware.js
+++ b/lib/oauth/token_refresh_middleware.js
@@ -46,19 +46,19 @@ function setupTokenRefreshHandler(token_endpoint) {
 				cookies.clearAccessToken(res)
 				cookies.clearRefreshToken(res)
 
-				delete req.cookies['access_token']
-				delete req.cookies['refresh_token']
+				delete req.cookies[cookies.COOKIE_ACCESS_TOKEN]
+				delete req.cookies[cookies.COOKIE_REFRESH_TOKEN]
 			} else log.error(error)
 
 			return next()
 		}
 
-		req.cookies['access_token'] = fresh.access_token
+		req.cookies[cookies.COOKIE_ACCESS_TOKEN] = fresh.access_token
 		cookies.setAccessToken(res, fresh.access_token, fresh.expires_in)
 
 		if (fresh.refresh_token) {
 			cookies.setRefreshToken(res, fresh.refresh_token)
-			req.cookies['refresh_token'] = fresh.refresh_token
+			req.cookies[cookies.COOKIE_REFRESH_TOKEN] = fresh.refresh_token
 		}
 
 		next()


### PR DESCRIPTION
The problem was I forgot to use the TOKEN_COOKIES_PREFIX when patching the incoming request with new tokens after a token refresh. 

To test:
1. `git checkout master`
2. Add `TOKEN_COOKIES_PREFIX=test_` to the .env file
3. `make run`
4. Log in, then wait for the access token to expire.
5. After the access token has expired, call /userinfo
Expected result is a 401 response.

Then:
1. `git checkout 42-userinfo-not-refreshing-token`
2. `make run` with the `TOKEN_COOKIES_PREFIX=test_` still in the .env file
3. Step 4 and 5 from earlier
Expected result is a 200 response containing user info

Closes #42 